### PR TITLE
Add support for user-specified public directory

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -40,6 +40,7 @@ API.prototype.defaults = {
   port: "3000",
   auth: false,
   CORS: "",
+  serveDir: __dirname + "/../node_modules/robeaux/",
   ssl: {
     key: path.normalize(__dirname + "/../ssl/server.key"),
     cert: path.normalize(__dirname + "/../ssl/server.crt")
@@ -73,7 +74,7 @@ API.prototype.configureMiddleware = function configureMiddleware() {
   this.express.use(bodyParser.urlencoded({ extended: true }));
 
   // serve static content
-  this.express.use(express["static"](__dirname + "/../node_modules/robeaux/"));
+  this.express.use(express["static"](this.serveDir));
 
   // set CORS headers for API requests
   this.express.use(function(req, res, next) {


### PR DESCRIPTION
Still defaults to Robeaux.

Open to suggestions if `serveDir` isn't the best possible option name.

``` javascript
var Cylon = require("cylon");

Cylon.api({
  serveDir: "./public"
});

// rest of program
```
